### PR TITLE
use aarch64 specific version of s6 overlay

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,10 @@
 FROM scratch
 ADD rootfs.tar.gz /
+MAINTAINER sparklyballs
 
 # set version for s6 overlay
 ARG OVERLAY_VERSION="v1.19.1.1"
+ARG OVERLAY_ARCH="aarch64"
 
 # environment variables
 ENV PS1="$(whoami)@$(hostname):$(pwd)$ " \
@@ -18,15 +20,13 @@ RUN \
 	bash \
 	ca-certificates \
 	coreutils \
-	s6 \
-	s6-portable-utils \
 	shadow \
 	tzdata && \
 
 # add s6 overlay
  curl -o \
  /tmp/s6-overlay.tar.gz -L \
-	"https://github.com/just-containers/s6-overlay/releases/download/${OVERLAY_VERSION}/s6-overlay-nobin.tar.gz" && \
+	"https://github.com/just-containers/s6-overlay/releases/download/${OVERLAY_VERSION}/s6-overlay-${OVERLAY_ARCH}.tar.gz" && \
  tar xfz \
 	/tmp/s6-overlay.tar.gz -C / && \
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 [Dockerfile](https://github.com/linuxserver/docker-baseimage-alpine-arm64/blob/master/Dockerfile)
 
-[![](https://images.microbadger.com/badges/image/lsiobase/alpine.arm64.svg)](https://microbadger.com/images/lsiobase/alpine.arm64 "Get your own image badge on microbadger.com")[![Build Status](http://jenkins.linuxserver.io:8080/job/Dockers/job/BaseImages-armhf/job/lsiobase-alpine.arm64/badge/icon)](http://jenkins.linuxserver.io:8080/job/Dockers/job/BaseImages-armhf/job/lsiobase-alpine.arm64/)
+[![](https://images.microbadger.com/badges/image/lsiobase/alpine.arm64.svg)](https://microbadger.com/images/lsiobase/alpine.arm64 "Get your own image badge on microbadger.com")[![Build Status](http://jenkins.linuxserver.io:8080/job/Dockers/job/BaseImages-arm64/job/lsiobase-alpine.arm64/badge/icon)](http://jenkins.linuxserver.io:8080/job/Dockers/job/BaseImages-arm64/job/lsiobase-alpine.arm64/)
 
 ### This base container is not aimed at public consumption. It exists to serve as a single endpoint for LinuxServer.io arm64 containers and is based upon [Alpine Linux](https://hub.docker.com/_/alpine/) and [S6 overlay](https://github.com/just-containers/s6-overlay).
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]
	

<!--- Before submitting a pull request please check the following -->

<!---  That you have made a branch in your fork, we'd rather not merge from your master -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!---  -->

##  Thanks, team linuxserver.io

+ use s6 overlay aarch64 specific version